### PR TITLE
Don't override system error

### DIFF
--- a/label/label_selinux.go
+++ b/label/label_selinux.go
@@ -142,7 +142,7 @@ func Relabel(path string, fileLabel string, shared bool) error {
 		fileLabel = c.Get()
 	}
 	if err := selinux.Chcon(path, fileLabel, true); err != nil {
-		return fmt.Errorf("SELinux relabeling of %s is not allowed: %q", path, err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
The error message added here provides no value as the caller already
knows all the added details. However it is covering up the underyling
system error (typically `ENOTSUP`). There is no way to handle this error before
this change.

This is the same change as opencontainers/runc#1339